### PR TITLE
Tweak focus behaviour for summary on clientside form validation

### DIFF
--- a/src/land_registry_elements/clientside-form-validation/Validator.js
+++ b/src/land_registry_elements/clientside-form-validation/Validator.js
@@ -259,9 +259,10 @@ function Validator (element, config) {
 
       if (!options.showSummary) {
         errorSummary.addClass('visuallyhidden')
+        $element.before(errorSummary)
+      } else {
+        $('h1').before(errorSummary)
       }
-
-      $('h1').before(errorSummary)
     }
 
     if (data.errors.length > 0) {


### PR DESCRIPTION
If we're not showing the summary, we don't want to put it all the way above the h1
because when we set keyboard focus on it, it will jump the page up.
Instead - place the hidden summary immediately before the form

